### PR TITLE
Removed extra comma

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -51,7 +51,7 @@
                         },
                         {
                             "command": "open_file",
-                            "args": {"file": "${packages}/User/Default.sublime-keymap", },
+                            "args": {"file": "${packages}/User/Default.sublime-keymap" },
                             "caption": "Key Bindings – User"
                         },
                         { "caption": "-" }


### PR DESCRIPTION
Fixed Error trying to parse file: Trailing comma before closing bracket in E:\Sublime_Text_x64\Data\Packages\PlainNotes\Main.sublime-menu:54:89
