### PR TITLE
Close the view when deleting a note

### DIFF
--- a/notes.py
+++ b/notes.py
@@ -302,6 +302,9 @@ class NoteRemoveCommand(sublime_plugin.WindowCommand):
         f_path = self.window.active_view().file_name()
         delete = sublime.ok_cancel_dialog('Are you sure you want to delete this note?', 'Yes')
         if delete:
+            # Set the view to scratch and close it so ST doesn't prompt again.
+            self.window.active_view().set_scratch(True)
+            self.window.run_command("close_file")
             os.remove(f_path)
 
     def is_enabled(self):


### PR DESCRIPTION
Deleting a note always acts on the active view - so close it (even if there are unsaved changes) before deleting.  Otherwise you just get ST prompting you again.

Using ```self.window.run_command("close_file")``` instead of ```self.window.active_view().close()``` for ST2-compatibility.

Tested on (Windows) ST3.  Checked the commands for ST2, but was having trouble with the plugin itself - is ST2 still supposed to be supported ([PackageControl](https://packagecontrol.io/packages/PlainNotes) thinks so).