### PR TITLE
Change e-mail regex to support '+' character

### DIFF
--- a/Note.sublime-syntax
+++ b/Note.sublime-syntax
@@ -715,7 +715,7 @@ contexts:
     - match: " {2,}$"
       scope: meta.dummy.line-break
   link-email:
-    - match: '(<)?((?:mailto:)?[-.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(>)?'
+    - match: '(<)?((?:mailto:)?[-+.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(>)?'
       scope: meta.link.email.lt-gt.markdown
       captures:
         1: punctuation.definition.link.markdown

--- a/Note.tmLanguage
+++ b/Note.tmLanguage
@@ -1751,7 +1751,7 @@
         </dict>
       </dict>
       <key>match</key>
-      <string>(&lt;)?((?:mailto:)?[-.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(&gt;)?</string>
+      <string>(&lt;)?((?:mailto:)?[-+.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(&gt;)?</string>
       <key>name</key>
       <string>meta.link.email.lt-gt.markdown</string>
     </dict>


### PR DESCRIPTION
The regex for e-mails didn't take into account that the __+__ character is valid in the left side of the e-mail.

E-mails like __xpto+xyz@xyz.com__ were only being partially matched.