### PR TITLE
Add setting to set a default color for new notes

### DIFF
--- a/Notes.sublime-settings
+++ b/Notes.sublime-settings
@@ -1,6 +1,7 @@
 {
   "root": "~/Dropbox/Notes/",
   "archive_dir": ".archive",
+  "note_color_scheme": "Packages/PlainNotes/Color Schemes/Sticky-Yellow.tmTheme",
   "jotter_color_scheme": "Packages/PlainNotes/Color Schemes/Sticky-Yellow.tmTheme",
   "jotter_date_format" :"%d %b %Y",
   "jotter_time_format": "%I:%M %p",

--- a/note_support.py
+++ b/note_support.py
@@ -7,6 +7,10 @@ import struct
 
 ST3072 = int(sublime.version()) >= 3072
 
+def is_enabled_for_view(view):
+    valid_syntax = ['Note.tmLanguage', 'Note.sublime-syntax']
+    syntax = view.settings().get("syntax")
+    return any(syntax.endswith(s) for s in valid_syntax)
 
 class NoteOpenUrlCommand(sublime_plugin.TextCommand):
 
@@ -18,7 +22,7 @@ class NoteOpenUrlCommand(sublime_plugin.TextCommand):
         webbrowser.open_new_tab(url)
 
     def is_enabled(self):
-        return 'Note.tmLanguage' in self.view.settings().get("syntax")
+        return is_enabled_for_view(self.view)
 
 if ST3072:
     class NotePreviewImageCommand(sublime_plugin.TextCommand):
@@ -118,4 +122,4 @@ if ST3072:
             return content_type, width, height
 
         def is_enabled(self):
-            return 'Note.tmLanguage' in self.view.settings().get("syntax")
+            return is_enabled_for_view(self.view)

--- a/notes.py
+++ b/notes.py
@@ -150,6 +150,9 @@ class NotesNewCommand(sublime_plugin.ApplicationCommand):
         if not os.path.exists(file):
             open(file, 'w+').close()
         view = sublime.active_window().open_file(file)
+        color_scheme = settings().get("note_color_scheme")
+        if color_scheme:
+            view.settings().set("color_scheme", color_scheme)
         self.insert_title_scheduled = False
         self.insert_title(title, tag, view)
 

--- a/notes.py
+++ b/notes.py
@@ -153,6 +153,11 @@ class NotesNewCommand(sublime_plugin.ApplicationCommand):
         color_scheme = settings().get("note_color_scheme")
         if color_scheme:
             view.settings().set("color_scheme", color_scheme)
+            f_id = file_id(file)
+            if not db.get(f_id):
+                db[f_id] = {}
+            db[f_id]["color_scheme"] = color_scheme
+            save_to_brain()
         self.insert_title_scheduled = False
         self.insert_title(title, tag, view)
 


### PR DESCRIPTION
The default color for new notes can now be configured through the __note_color_scheme__ setting.

Closes #44 