### PR TITLE
Make the Jotter directory name editable in the settings

### DIFF
--- a/Notes.sublime-settings
+++ b/Notes.sublime-settings
@@ -5,6 +5,7 @@
   "jotter_color_scheme": "Packages/PlainNotes/Color Schemes/Sticky-Yellow.tmTheme",
   "jotter_date_format" :"%d %b %Y",
   "jotter_time_format": "%I:%M %p",
+  "jotter_dir": ".brain",
   "note_save_extension": "note",
   "note_file_extensions": ["md","note"],
   "enable_yaml": false,

--- a/jotter.py
+++ b/jotter.py
@@ -15,6 +15,13 @@ def settings():
 def get_root():
     return os.path.normpath(os.path.expanduser(settings().get("root")))
 
+def brain_dir():
+    brain_settings = settings().get("jotter_dir")
+    if brain_settings:
+        return brain_settings
+    else:
+        return ".brain"
+
 
 class JotterCommand(sublime_plugin.TextCommand):
     def run(self, edit):
@@ -46,7 +53,7 @@ class SaveJotAndHidePanelCommand(sublime_plugin.TextCommand):
 
         jot = '# ' + time.strftime(settings().get("jotter_date_format")) + u' — ' + time.strftime(settings().get("jotter_time_format")) + u'\n' + text.rstrip(u'\r\n') + u'\n\n'
 
-        with open(os.path.join(get_root(), ".brain", "Inbox.note"), mode='r+', encoding='utf-8') as f:
+        with open(os.path.join(get_root(), brain_dir(), "Inbox.note"), mode='r+', encoding='utf-8') as f:
             content = f.read()
             f.seek(0, 0)
             f.write(jot + content)
@@ -57,6 +64,6 @@ class SaveJotAndHidePanelCommand(sublime_plugin.TextCommand):
 class OpenInboxCommand(sublime_plugin.ApplicationCommand):
     def run(self):
         root = get_root()
-        inbox = os.path.join(root, '.brain', 'Inbox.note')
+        inbox = os.path.join(root, brain_dir(), 'Inbox.note')
         sublime.active_window().open_file(inbox)
 

--- a/notes.py
+++ b/notes.py
@@ -28,6 +28,13 @@ def get_root():
 def file_id(path):
     return os.path.relpath(path, root)
 
+def brain_dir():
+    brain_settings = settings().get("jotter_dir")
+    if brain_settings:
+        return brain_settings
+    else:
+        return ".brain"
+
 
 def find_notes(self, root, exclude):
     note_files = []
@@ -37,7 +44,7 @@ def find_notes(self, root, exclude):
         relpath = os.path.relpath(path, root)
         for name in files:
             for ext in settings().get("note_file_extensions"):
-                if (not relpath.startswith(".brain")) and fnmatch.fnmatch(name, "*." + ext):
+                if (not relpath.startswith(brain_dir())) and fnmatch.fnmatch(name, "*." + ext):
                     title = re.sub('\.' + ext + '$', '', name)
                     tag = path.replace(root, '').replace(os.path.sep, '')
                     if not tag == '':
@@ -92,7 +99,7 @@ def update_color(old_file_path, new_file_path):
 class NotesListCommand(sublime_plugin.ApplicationCommand):
 
     def run(self):
-        exclude = set([settings().get("archive_dir"), '.brain'])
+        exclude = set([settings().get("archive_dir"), brain_dir()])
         root = get_root()
         self.notes_dir = root
         self.file_list = find_notes(self, root, exclude)
@@ -403,9 +410,9 @@ def plugin_loaded():
     # creating directory structure and files in root
     db = {}
     root = get_root()
-    brain = os.path.join(root, '.brain')
-    inbox = os.path.join(root, '.brain', 'Inbox.note')
-    db_json_file = os.path.join(root, '.brain', 'brain.json')
+    brain = os.path.join(root, brain_dir())
+    inbox = os.path.join(root, brain_dir(), 'Inbox.note')
+    db_json_file = os.path.join(root, brain_dir(), 'brain.json')
 
     if not os.path.exists(brain):
         os.makedirs(brain)

--- a/notes_index.py
+++ b/notes_index.py
@@ -18,6 +18,13 @@ def get_root():
     else:
         return os.path.normpath(os.path.expanduser(settings().get("root")))
 
+def brain_dir():
+    brain_settings = settings().get("jotter_dir")
+    if brain_settings:
+        return brain_settings
+    else:
+        return ".brain"
+
 
 class NotesBufferCommand(sublime_plugin.WindowCommand):
     def run(self):
@@ -56,7 +63,7 @@ class NotesBufferRefreshCommand(sublime_plugin.TextCommand):
             if relpath.startswith(settings().get("archive_dir")):
                 line_str = u'{0}▣ {1}'.format(indent, 'Archive')
                 lines.append((line_str, root))
-            if not relpath.startswith(".brain"):
+            if not relpath.startswith(brain_dir()):
                 subindent = ' ' * TAB_SIZE * (level + 1)
                 for f in files:
                     for ext in settings().get("note_file_extensions"):  # display only files with given extension


### PR DESCRIPTION
allows for it to be set as a path that is not hidden,
defaults to .brain so that default functionality does not change