### PR TITLE
Allow note colors for non-note files that use Set Syntax.

### DIFF
--- a/notes.py
+++ b/notes.py
@@ -214,6 +214,8 @@ class NoteChangeColorCommand(sublime_plugin.WindowCommand):
         self.window = sublime.active_window()
         self.original_cs = self.window.active_view().settings().get("color_scheme")
         current_color = os.path.basename(self.original_cs).replace("Sticky-", "").replace(".tmTheme", "")
+        if not current_color in self.colors:
+            current_color = "Yellow"
         if ST3:
             self.window.show_quick_panel(self.colors, self.on_select, 0, self.colors.index(current_color), self.on_highlight)
         else:


### PR DESCRIPTION
It's possible to use PlainNotes to set the syntax (`Set Syntax: Note`) for files not created using PlainNotes, such as a generic `.md`. But when you try to change the file's note color (`Notes: Change Color...`), you get an error:

```
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 1036, in run_
    return self.run()
  File "/Users/REDACTED/Library/Application Support/Sublime Text 3/Installed Packages/PlainNotes.sublime-package/notes.py", line 218, in run
ValueError: 'Boxy Yesterday' is not in list
```
where `Boxy Yesterday` is the Sublime Text theme.

This change sets "Yellow" as the fallback color so that changing the color doesn't fail.