### PR TITLE
Add Stata & R support in fenced code blocks

### DIFF
--- a/Note-fenced.sublime-syntax
+++ b/Note-fenced.sublime-syntax
@@ -33,6 +33,7 @@ contexts:
     - include: fenced-scss
     - include: fenced-shell
     - include: fenced-sql
+    - include: fenced-stata
     - include: fenced-tex
     - include: fenced-xml
     - include: fenced-yaml
@@ -296,12 +297,13 @@ contexts:
           pop: true
         - include: scope:source.python
   fenced-r:
-    - match: '((?:^|\G)\s*[`~]{3,})\s*(r)\s*$'
+    - match: '((?:^|\G)\s*[`~]{3,})\s*(r|{r}|{r(\s|\,).*})\s*$'
       captures:
         1: punctuation.definition.raw.block.fenced.markdown
         2: meta.definition.language.raw.block.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown meta.language.r
+        - meta_content_scope: source.r
         - match: '^(\1)[ \t]*(\n|$)'
           captures:
             1: punctuation.definition.raw.block.fenced.markdown
@@ -399,6 +401,20 @@ contexts:
             2: meta.definition.language.raw.block.fenced.markdown
           pop: true
         - include: scope:source.sql
+  fenced-stata:
+    - match: '((?:^|\G)\s*[`~]{3,})\s*(s|stata|{s}|{s(\s|\,).*}|{stata}|{stata(\s|\,).*})\s*$'
+      captures:
+        1: punctuation.definition.raw.block.fenced.markdown
+        2: meta.definition.language.raw.block.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown meta.language.stata 
+        - meta_content_scope: source.stata
+        - match: '^(\1)[ \t]*(\n|$)'
+          captures:
+            1: punctuation.definition.raw.block.fenced.markdown
+            2: meta.definition.language.raw.block.fenced.markdown
+          pop: true
+        - include: scope:source.stata
   fenced-tex:
     - match: '((?:^|\G)\s*[`~]{3,})\s*(tex)\s*$'
       captures:

--- a/Note-fenced.tmLanguage
+++ b/Note-fenced.tmLanguage
@@ -291,6 +291,36 @@
         </array>
     </dict>
 
+    <key>fenced-stata</key>
+    <dict>
+        <key>begin</key>
+        <string>((?:^|\G)\s*[`~]{3,})\s*(s|stata|{s}|{s(\s|\,).*}|{stata}|{stata(\s|\,).*})\s*$</string>
+        <key>end</key>
+        <string>^(\1)[ \t]*(\n|$)</string>
+        <key>name</key>
+        <string>markup.raw.block.markdown markup.raw.block.fenced.markdown meta.language.stata</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.raw.block.fenced.markdown</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>meta.definition.language.raw.block.fenced.markdown</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+            <dict>
+                <key>include</key>
+                <string>source.stata</string>
+            </dict>
+        </array>
+    </dict>
+
     <key>fenced-shell</key>
     <dict>
         <key>begin</key>
@@ -624,7 +654,7 @@
     <key>fenced-r</key>
     <dict>
         <key>begin</key>
-        <string>((?:^|\G)\s*[`~]{3,})\s*(r)\s*$</string>
+        <string>((?:^|\G)\s*[`~]{3,})\s*(r|{r}|{r(\s|\,).*})\s*$</string>
         <key>end</key>
         <string>^(\1)[ \t]*(\n|$)</string>
         <key>name</key>

--- a/Note-fenced.tmLanguage
+++ b/Note-fenced.tmLanguage
@@ -1036,6 +1036,10 @@
         </dict>
         <dict>
           <key>include</key>
+          <string>#fenced-stata</string>
+        </dict>
+        <dict>
+          <key>include</key>
           <string>#fenced-shell</string>
         </dict>
         <dict>


### PR DESCRIPTION
If opening fence is either \```s, \```{s}, \```stata or \```{stata},
fenced code block will highlight Stata syntax and support any key bindings working in source.stata.

If opening fence is either \```r or \```{r}, fenced code block will
highlight R syntax and support any key bindings working in source.r.

Also, syntax highlighting will work when adding code chunk options
such as \```{r, eval=FALSE} of R Markdown.